### PR TITLE
fix broken markdown formatting

### DIFF
--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -535,7 +535,7 @@ Interceptor.attach(Module.findExportByName("libc.so", "read"), {
 });
 {% endhighlight %}
 
-    Additionally, the object contains some useful properties:
++   Additionally, the object contains some useful properties:
 
     -   `context`: object with the keys `pc` and `sp`, which are
         NativePointer objects specifying EIP/RIP/PC and ESP/RSP/SP,


### PR DESCRIPTION
highlight block breaks indention of the following text, so md interprets that text as code block. fixed making list item