### PR TITLE
Updated ObjC documentation

### DIFF
--- a/_docs/examples/ios.md
+++ b/_docs/examples/ios.md
@@ -209,9 +209,9 @@ var openURL = ObjC.classes.UIApplication["- openURL:"];
 Interceptor.attach(openURL.implementation, {
   onEnter: function(args) {
     // As this is an ObjectiveC method, the arguments are as follows:
-    // 1. 'self'
-    // 2. The selector (openURL:)
-    // 3. The first argument to the openURL selector
+    // 0. 'self'
+    // 1. The selector (openURL:)
+    // 2. The first argument to the openURL selector
     var myNSURL = new ObjC.Object(args[2]);
     // Convert it to a JS string
     var myJSURL = myNSURL.absoluteString().toString();

--- a/_docs/examples/ios.md
+++ b/_docs/examples/ios.md
@@ -195,3 +195,28 @@ ObjC.schedule(ObjC.mainQueue, function () {
   UIApplication.sharedApplication().keyWindow().rootViewController().presentViewController_animated_completion_(alert, true, NULL);
 })
 {% endhighlight %}
+
+
+### Printing an NSURL argument
+
+The following code shows how you can intercept a call to [UIApplication openURL:] and display the NSURL that is passed.
+
+{% highlight js %}
+// Get a reference to the openURL selector
+var openURL = ObjC.classes.UIApplication["- openURL:"];
+
+// Intercept the method
+Interceptor.attach(openURL.implementation, {
+  onEnter: function(args) {
+    // As this is an ObjectiveC method, the arguments are as follows:
+    // 1. 'self'
+    // 2. The selector (openURL:)
+    // 3. The first argument to the openURL selector
+    var myNSURL = new ObjC.Object(args[2]);
+    // Convert it to a JS string
+    var myJSURL = myNSURL.absoluteString().toString();
+    // Log it
+    console.log("Launching URL: " + str);
+  }
+});
+{% endhighlight %}

--- a/_docs/examples/ios.md
+++ b/_docs/examples/ios.md
@@ -216,7 +216,7 @@ Interceptor.attach(openURL.implementation, {
     // Convert it to a JS string
     var myJSURL = myNSURL.absoluteString().toString();
     // Log it
-    console.log("Launching URL: " + str);
+    console.log("Launching URL: " + myJSURL);
   }
 });
 {% endhighlight %}

--- a/_docs/javascript-api.md
+++ b/_docs/javascript-api.md
@@ -1164,7 +1164,13 @@ ObjC.schedule(ObjC.mainQueue, function () {
     implementing a certain protocol only.
 
 {% highlight js %}
-var sound = new ObjC.Object(ptr("0x1234"));
+Interceptor.attach(myFunction.implementation, {
+  onEnter: function(args) {
+    // ObjC: args[0] = self, args[1] = selector, args[2-n] = arguments
+    var myString = new ObjC.Object(args[2]);
+    console.log("String argument: " + myString.toString());
+  }
+});
 {% endhighlight %}
 
 >   This object has some special properties:


### PR DESCRIPTION
I've added some information in two different places. More specifically, this is some documentation for the ObjC.Object function in combination with the interceptor.

One iOS example was added with a little bit of information. A shorter version of the example replaces the current example for ObjC.Object to also provide a little bit of extra information for that specific usage.