### PR TITLE
document the Java.scheduleOnMainThread() method

### DIFF
--- a/_docs/javascript-api.md
+++ b/_docs/javascript-api.md
@@ -1501,6 +1501,8 @@ Java.perform(function () {
 });
 {% endhighlight %}
 
++   `Java.scheduleOnMainThread(fn)`: run `fn` on the main thread of the VM.
+
 +   `Java.choose(className, callbacks)`: enumerate live instances of the
     `className` class by scanning the Java heap, where `callbacks` is an
     object specifying:


### PR DESCRIPTION
added in 2a90aec3fc826d3be6df6e3e0a56d0874d504840. This method is useful for calling methods that must be executed from the main thread, e.g. WebView.setWebContentsDebuggingEnabled()