### PR TITLE
rpc example: items in export should be key:value pairs

### DIFF
--- a/_docs/javascript-api.md
+++ b/_docs/javascript-api.md
@@ -131,10 +131,10 @@ console.log(hexdump(buf, {
 'use strict';
 
 rpc.exports = {
-    add(a, b) {
+    add: function (a, b) {
         return a + b;
     },
-    sub(a, b) {
+    sub: function (a, b) {
         return new Promise(resolve => {
             setTimeout(() => {
                 resolve(a - b);


### PR DESCRIPTION
This is described correctly in the text, but the example is incorrect...