### PR TITLE
Remove the table from the C docs

### DIFF
--- a/_docs/c-api.md
+++ b/_docs/c-api.md
@@ -8,17 +8,30 @@ permalink: /docs/c-api/
 
 The functionality that provides you the JavaScript API for injection, function manipulation, memory reading, and more is also available from C.
 
-Frida is broken down into several modules:
+Frida is broken down into several modules, which we will discuss below.    These can each be compiled individually and are also available on [the releases page](https://github.com/frida/frida/releases).
 
-| Project Name | Description | Repository |
-|---|---|---|
-|core|process injection|https://github.com/frida/frida-core|
-|gum|augment or replace functions|https://github.com/frida/frida-gum|
-|gumjs|JavaScript bindings|
-|gadget|similar to frida-agent except to either DYLD_INSERT_LIBRARIES, bundle with an app, etc. and it can run either in a remote mode where it listens and looks just like frida-server|
+The devkit downloads come with an example on how to use each module.  Using the devkits is the best way to learn how to utilize each module
 
-These can each be compiled individually and are also available on [the releases page](https://github.com/frida/frida/releases).
+## core
 
-The devkit downloads come with an example on how to use each module.
+frida-core contains the main injection code.  From frida-core, you can inject into a process, create a thread running V8, and run your JavaScript.
+
+See the [frida-core](https://github.com/frida/frida-core) repository for the source.
+
+## gum
+
+frida-gum allows you to augment and replace functions using C.
+
+The example in the devkit shows you how to augment `open` and `close` from C only.
+
+See the [frida-gum](https://github.com/frida/frida-gum) repository for the source.
+
+## gumjs
+
+frida-gumjs contains the JavaScript bindings
+
+## gadget
+
+Similar to frida-agent except to either DYLD_INSERT_LIBRARIES, bundle with an app, etc. and it can run either in a remote mode where it listens and looks just like frida-server
 
 _Please click "Improve this page" above and add an example. Thanks!_


### PR DESCRIPTION
Change the table into a set of headers with comments.

Primarily because the CSS for Markdown tables is broken, so the text was grey on grey.

It also makes it more similar to the other pages.