### PR TITLE
Add more details to build on Ubuntu 14.04

### DIFF
--- a/_docs/building.md
+++ b/_docs/building.md
@@ -64,6 +64,16 @@ below.
 $ sudo apt-get install build-essential gcc-multilib git lib32stdc++-4.9-dev \
     lib32z1-dev python-dev python3-dev zlib1g-dev
 {% endhighlight %}
+
+  - Development toolchain Ubuntu 14.04 (Trusty Jahr) with Node 7.x
+  See [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager/) for more installation options
+{% highlight bash %}
+$ curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+$ sudo apt-get install -y nodejs
+$ sudo apt-get install build-essential gcc-multilib git lib32stdc++-4.8-dev \
+    lib32z1-dev python-dev python3-dev zlib1g-dev
+{% endhighlight %}
+
 - Clone `frida` and build it:
 {% highlight bash %}
 $ git clone git://github.com/frida/frida.git


### PR DESCRIPTION
I replaced lib32stdc++-4.9-dev by lib32stdc++-4.8-dev 

as 4.9 doesn't seem to be available on Ubuntu 14.04

http://packages.ubuntu.com/trusty/libstdc++-4.8-dev