### PR TITLE
Add in a few updates to the IOS/Obj-c docs

### DIFF
--- a/_docs/examples/ios.md
+++ b/_docs/examples/ios.md
@@ -101,7 +101,7 @@ Explanation [here](https://gist.github.com/dpnishant/c7c6b47ebfd8cd671ecf).
 
 ## Data Structures
 
->**Tip**: If things don't seem to be working as expected you may be interacting with the wrong data type - run `log("Type of args[2] -> " + ObjC.Object(args[2]).$className)` to check the type of class that was decoded!
+>**Tip**: If things don't seem to be working as expected you may be interacting with the wrong data type - run `console.log("Type of args[2] -> " + new ObjC.Object(args[2]).$className)` to determine the actual type of the object that you're dealing with!
 
 1. Converting NSData to String
 -
@@ -122,8 +122,8 @@ Memory.readByteArray(data.bytes(), data.length());
 -
 ```
 var array = new ObjC.Object(args[2]);
-var count = array.count().valueOf();
-for (var i = 0; i < count; i++) {
+var count = array.count().valueOf();  // Be sure to use valueOf!
+for (var i = 0; i !== count; i++) {
   var element = array.objectAtIndex_(i);
 }
 ```

--- a/_docs/examples/ios.md
+++ b/_docs/examples/ios.md
@@ -101,6 +101,8 @@ Explanation [here](https://gist.github.com/dpnishant/c7c6b47ebfd8cd671ecf).
 
 ## Data Structures
 
+>**Tip**: If things don't seem to be working as expected you may be interacting with the wrong data type - run `log("Type of args[2] -> " + ObjC.Object(args[2]).$className)` to check the type of class that was decoded!
+
 1. Converting NSData to String
 -
 ```
@@ -112,14 +114,16 @@ Memory.readUtf8String(data.bytes(), data.length());
 2. Converting NSData to Binary Data
 -
 ```
+var data = new ObjC.Object(args[2]);
 Memory.readByteArray(data.bytes(), data.length());
 ```
 
 3. Iterating an NSArray
 -
 ```
-var count = array.count();
-for (var i = 0; i !== count; i++) {
+var array = new ObjC.Object(args[2]);
+var count = array.count().valueOf();
+for (var i = 0; i < count; i++) {
   var element = array.objectAtIndex_(i);
 }
 ```
@@ -127,6 +131,7 @@ for (var i = 0; i !== count; i++) {
 4. Iterating an NSDictionary
 -
 ```
+var dict = new ObjC.Object(args[2]);
 var enumerator = dict.keyEnumerator();
 var key;
 while ((key = enumerator.nextObject()) !== null) {


### PR DESCRIPTION
There were a few things that were somewhat confusing to me when looking at this, so I tried to clarify them here:

- Add a big tip at the top showing how to examine the actual class type that was decoded using `ObjC.Object()`
- Expanded some examples to have more copy/paste-able code since `data`, `array`, and `dict` are all created the same way, which wasn't 100% obvious to me 
- I also added the `valueOf()` call to the array example which we discussed
- ~~I also fixed a bug in the loop logic, as iterating the length of the array ends up blowing things up for me (and seems to be a off-by-one issue).~~ - this was caused by the missing `valueOf()` call!

![](https://media.giphy.com/media/26BGM86XngBjKOqXu/giphy.gif)

Thanks again for your help tonight!