### PR TITLE
Improve Android documentation

### DIFF
--- a/_docs/android.md
+++ b/_docs/android.md
@@ -28,8 +28,13 @@ significantly less testing.)
 You will also need the `adb` tool from the Android SDK.
 
 First off, download the latest `frida-server` for Android from our [releases
-page](https://github.com/frida/frida/releases) and get it running on your
-device:
+page](https://github.com/frida/frida/releases) and uncompress it.
+
+{% highlight bash %}
+unxz frida-server.xz
+{% highlight bash %}
+
+Now, let's get it running on your device:
 
 {% highlight bash %}
 $ adb root # might be required


### PR DESCRIPTION
The Android documentation could use an enhancement for instructions on decompressing XZ files. It took me a few minutes to find that it needed to be decompressed as well as the correct utility. Other users have run into this in the past too.
https://github.com/frida/frida/issues/364
https://github.com/frida/frida/issues/367

It's a bit more verbose but can help beginners like myself.