### PR TITLE
clarify what Module.load() expects

### DIFF
--- a/_i18n/en/_docs/javascript-api.md
+++ b/_i18n/en/_docs/javascript-api.md
@@ -469,8 +469,9 @@ In the example above we used `script.on('message', on_message)` to monitor for a
     *find*-prefixed function returns *null* whilst the *get*-prefixed function
     throws an exception.
 
-+   `Module.load(name)`: loads the specified module and returns a `Module`
-    object. Throws an exception if the specified module cannot be loaded.
++   `Module.load(path)`: loads the specified module from the filesystem path
+    and returns a `Module` object. Throws an exception if the specified module
+    cannot be loaded.
 
 +   `Module.ensureInitialized(name)`: ensures that initializers of the specified
     module have been run. This is important during early instrumentation, i.e.


### PR DESCRIPTION
Based on experience using the library and reading the gum code, it looks like Module.load() expects a file system path. The documentation implies that it expects the name of the module.