### PR TITLE
Add more detailed build instructions for Windows 

### DIFF
--- a/_i18n/en/_docs/building.md
+++ b/_i18n/en/_docs/building.md
@@ -87,8 +87,8 @@ Running `make` will provide you a list of modules to build. See
 
 - Make sure you have:
   - Visual Studio 2019 w/XP support
-    - select `Desktop development with C++` workload
-    - select the `C++ Windows XP Support for VS 2017 (v141) tools [Deprecated]` individual component
+    - Select `Desktop development with C++` workload
+    - Select the `C++ Windows XP Support for VS 2017 (v141) tools [Deprecated]` individual component
   - [Git](https://git-scm.com/downloads) on your PATH
   - [Python 3.8](https://www.python.org/downloads/windows/) on your path with `py` launcher installed
     - Select `Add Python 3.8 to PATH`

--- a/_i18n/en/_docs/building.md
+++ b/_i18n/en/_docs/building.md
@@ -1,4 +1,3 @@
-
 ## Table of contents
 
 1. Building Frida

--- a/_i18n/en/_docs/building.md
+++ b/_i18n/en/_docs/building.md
@@ -92,8 +92,8 @@ Running `make` will provide you a list of modules to build. See
   - [Git](https://git-scm.com/downloads) on your PATH
   - [Python 3.8](https://www.python.org/downloads/windows/) on your path with `py` launcher installed
     - Select `Add Python 3.8 to PATH`
-    - Specify the installation directory to `C:\Program Files (x86)\Python 3.8\`  (with spaces)
-    - select `Associate files with Python (requires the py launcher)`  option
+    - Specify the installation directory to `C:\Program Files (x86)\Python 3.8\` (with spaces)
+    - Select `Associate files with Python (requires the py launcher)` option
   - [Node.js](https://nodejs.org/) on your PATH
   - [PowerShell](https://msdn.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell)
 


### PR DESCRIPTION
Just to make things a little clearer about the steps required for successful builds under Windows.

- Python38 has to be in a specific directory otherwise `frida-python` will not find the necessary includes
- make it marginally clearer about the setup  of visual studio and setting up of python