### PR TITLE
Remove page-breaking example

### DIFF
--- a/_i18n/en/_docs/javascript-api.md
+++ b/_i18n/en/_docs/javascript-api.md
@@ -1077,16 +1077,6 @@ Kernel.protect(UInt64('0x1234'), 4096, 'rw-');
         passed in as the first parameter. (This scenario is common in WebKit,
         for example.)
 
-        Example:
-{% highlight js %}
-// LargeObject HandyClass::friendlyFunctionName();
-const friendlyFunctionName = new NativeFunction(friendlyFunctionPtr,
-    'void', ['pointer', 'pointer']);
-const returnValue = Memory.alloc(sizeOfLargeObject);
-friendlyFunctionName(returnValue, thisPtr);
-{% endhighlight %}
-
-+
     - #### Supported Types
         -   void
         -   pointer


### PR DESCRIPTION
Syntax-highlighted blocks of code are not supported in lists so the example must be removed.