### PR TITLE
Added info about android roduction builds when using adb root

### DIFF
--- a/_i18n/en/_docs/android.md
+++ b/_i18n/en/_docs/android.md
@@ -41,6 +41,12 @@ For the last step, make sure you start frida-server as root, i.e. if you are
 doing this on a rooted device, you might need to *su* and run it from that
 shell.
 
+<div class="note info">
+  <h5>adb on a production build</h5>
+  <p>If you get <code>adbd cannot run as root in production builds</code> after running <code>adb root</code><br>you need to add <code>su -c</code>in the beginning of each adb shell. for example: <code>adb shell "su -c chmod 755 /data/local/tmp/frida-server"</code></p>
+  
+</div>
+
 Next, make sure `adb` can see your device:
 
 {% highlight bash %}

--- a/_i18n/en/_docs/android.md
+++ b/_i18n/en/_docs/android.md
@@ -43,8 +43,12 @@ shell.
 
 <div class="note info">
   <h5>adb on a production build</h5>
-  <p>If you get <code>adbd cannot run as root in production builds</code> after running <code>adb root</code><br>you need to add <code>su -c</code>in the beginning of each adb shell. for example: <code>adb shell "su -c chmod 755 /data/local/tmp/frida-server"</code></p>
-  
+  <p>
+    If you get <code>adbd cannot run as root in production builds</code> after
+    running <code>adb root</code><br>you need to prefix each shell command with
+    <code>su -c</code>. For example:
+    <code>adb shell "su -c chmod 755 /data/local/tmp/frida-server"</code>
+  </p>
 </div>
 
 Next, make sure `adb` can see your device:


### PR DESCRIPTION
Added some clarity about using `adb root` on a device that might get this error:
`adbd cannot run as root in production builds`
![image](https://user-images.githubusercontent.com/59445372/124392904-2ffc5c00-dcf8-11eb-9b75-678d4f51ca9b.png)
