### PR TITLE
Fix wrong date in documentation

### DIFF
--- a/_i18n/en/_posts/2021-06-16-frida-15-0-released.markdown
+++ b/_i18n/en/_posts/2021-06-16-frida-15-0-released.markdown
@@ -1,7 +1,7 @@
 ---
 layout: news_item
 title: 'Frida 15.0 Released'
-date: 2021-06-16 23:00:00 +0200
+date: 2021-07-16 23:00:00 +0200
 author: oleavr
 version: 15.0
 categories: [release]


### PR DESCRIPTION
The news was from July not from June