### PR TITLE
Remove redundant u prefix

### DIFF
--- a/_docs/examples/windows.md
+++ b/_docs/examples/windows.md
@@ -15,7 +15,6 @@ Save this code as *bb.py*, run BB Simulator (fledge.exe), then run
 *jvm.dll*.
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 

--- a/_i18n/en/_docs/examples/windows.md
+++ b/_i18n/en/_docs/examples/windows.md
@@ -9,7 +9,6 @@ Save this code as *bb.py*, run BB Simulator (fledge.exe), then run
 *jvm.dll*.
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 

--- a/_i18n/en/_docs/functions.md
+++ b/_i18n/en/_docs/functions.md
@@ -55,7 +55,6 @@ process and report back a function argument to you. Create a file `hook.py`
 containing:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 
@@ -84,8 +83,8 @@ $ python hook.py 0x400544
 This should give you a new message every second on the form:
 
 {% highlight py %}
-{u'type': u'send', u'payload': 531}
-{u'type': u'send', u'payload': 532}
+{'type': 'send', 'payload': 531}
+{'type': 'send', 'payload': 532}
 …
 {% endhighlight %}
 
@@ -208,7 +207,6 @@ to inject a string into memory, and then call the function f() in the following
 way:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 
@@ -371,7 +369,6 @@ Here's a script to inject the malicious struct into memory, and then hijack the
 Create the file `struct_mod.py` as follows:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 

--- a/_i18n/en/_docs/installation.md
+++ b/_i18n/en/_docs/installation.md
@@ -88,7 +88,7 @@ The output should be something similar to this (depending on your platform
 and library versions):
 
 {% highlight py %}
-[u'cat', …, u'ld-2.15.so']
+['cat', …, 'ld-2.15.so']
 {% endhighlight %}
 
 [PyPI]: https://pypi.python.org/pypi/frida-tools

--- a/_i18n/en/_docs/messages.md
+++ b/_i18n/en/_docs/messages.md
@@ -55,7 +55,6 @@ You can send any JavaScript value which is serializable to JSON.
 Create a file `send.py` containing:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 
@@ -77,7 +76,7 @@ $ python send.py
 it should print the following message:
 
 {% highlight py %}
-{u'type': u'send', u'payload': 1337}
+{'type': 'send', 'payload': 1337}
 {% endhighlight %}
 
 This means that the JavaScript code `send(1337)` has been executed inside the
@@ -91,7 +90,7 @@ with `send(a)` (an undefined variable), the following message will be received
 by Python:
 
 {% highlight py %}
-{u'type': u'error', u'description': u'ReferenceError: a is not defined', u'lineNumber': 1}
+{'type': 'error', 'description': 'ReferenceError: a is not defined', 'lineNumber': 1}
 {% endhighlight %}
 
 Note the `type` field (`error` vs `send`).
@@ -102,7 +101,6 @@ It is possible to send messages from the Python script to the JavaScript
 script. Create the file `pingpong.py`:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 
@@ -127,7 +125,7 @@ $ python pingpong.py
 produces the output:
 
 {% highlight py %}
-{u'type': u'send', u'payload': u'pokeBack'}
+{'type': 'send', 'payload': 'pokeBack'}
 {% endhighlight %}
 
 <div class="note info">
@@ -145,7 +143,6 @@ It is possible to wait for a message to arrive (a blocking receive) inside your
 JavaScript script. Create a script `rpc.py`:
 
 {% highlight py %}
-from __future__ import print_function
 import frida
 import sys
 

--- a/_i18n/en/_posts/2016-06-02-frida-7-2-released.markdown
+++ b/_i18n/en/_posts/2016-06-02-frida-7-2-released.markdown
@@ -60,7 +60,6 @@ co(function* () {
 And from Python:
 
 {% highlight python %}
-from __future__ import print_function
 import frida
 
 system_session = frida.attach(0)

--- a/_i18n/en/_posts/2018-04-28-frida-10-8-released.markdown
+++ b/_i18n/en/_posts/2018-04-28-frida-10-8-released.markdown
@@ -77,7 +77,6 @@ So that's the theory. Let's have a look at a practical [example][], using
 Frida's Python bindings:
 
 {% highlight python %}
-from __future__ import print_function
 import frida
 from frida.application import Reactor
 import threading


### PR DESCRIPTION
According to the above example.py, this doc uses Python3. As a result, it's weird for string with u prefix.