### PR TITLE
Address deprecation warning in sample script

### DIFF
--- a/_i18n/en/_docs/installation.md
+++ b/_i18n/en/_docs/installation.md
@@ -66,7 +66,7 @@ rpc.exports.enumerateModules = () => {
 script.on("message", on_message)
 script.load()
 
-print([m["name"] for m in script.exports.enumerate_modules()])
+print([m["name"] for m in script.exports_sync.enumerate_modules()])
 {% endhighlight %}
 
 If you are on GNU/Linux, issue:


### PR DESCRIPTION
Before:

```
me-mbp ~/w/frida$ python3 hello.py
/Users/me/w/frida/hello.py:16: DeprecationWarning: Script.exports will become asynchronous in the future, use the explicit Script.exports_sync instead
  print([m["name"] for m in script.exports.enumerate_modules()])
['yello', 'libSystem.B.dylib', 'libcache.dylib', 'libcommonCrypto.dylib', 'libcompiler_rt.dylib', 'libcopyfile.dylib', 'libcorecrypto.dylib', 'libdispatch.dylib', 'libdyld.dylib', 'libkeymgr.dylib', 'libmacho.dylib', 'libquarantine.dylib', 'libremovefile.dylib', 'libsystem_asl.dylib', 'libsystem_blocks.dylib', 'libsystem_c.dylib', 'libsystem_collections.dylib', 'libsystem_configuration.dylib', 'libsystem_containermanager.dylib', 'libsystem_coreservices.dylib', 'libsystem_darwin.dylib', 'libsystem_darwindirectory.dylib', 'libsystem_dnssd.dylib', 'libsystem_eligibility.dylib', 'libsystem_featureflags.dylib', 'libsystem_info.dylib', 'libsystem_m.dylib', 'libsystem_malloc.dylib', 'libsystem_networkextension.dylib', 'libsystem_notify.dylib', 'libsystem_sandbox.dylib', 'libsystem_sanitizers.dylib', 'libsystem_secinit.dylib', 'libsystem_kernel.dylib', 'libsystem_platform.dylib', 'libsystem_pthread.dylib', 'libsystem_symptoms.dylib', 'libsystem_trace.dylib', 'libunwind.dylib', 'libxpc.dylib', 'libobjc.A.dylib', 'libc++abi.dylib', 'liboah.dylib', 'libc++.1.dylib', 'dyld']
```

After:

```
me-mbp ~/w/frida$ python3 hello.py
['yello', 'libSystem.B.dylib', 'libcache.dylib', 'libcommonCrypto.dylib', 'libcompiler_rt.dylib', 'libcopyfile.dylib', 'libcorecrypto.dylib', 'libdispatch.dylib', 'libdyld.dylib', 'libkeymgr.dylib', 'libmacho.dylib', 'libquarantine.dylib', 'libremovefile.dylib', 'libsystem_asl.dylib', 'libsystem_blocks.dylib', 'libsystem_c.dylib', 'libsystem_collections.dylib', 'libsystem_configuration.dylib', 'libsystem_containermanager.dylib', 'libsystem_coreservices.dylib', 'libsystem_darwin.dylib', 'libsystem_darwindirectory.dylib', 'libsystem_dnssd.dylib', 'libsystem_eligibility.dylib', 'libsystem_featureflags.dylib', 'libsystem_info.dylib', 'libsystem_m.dylib', 'libsystem_malloc.dylib', 'libsystem_networkextension.dylib', 'libsystem_notify.dylib', 'libsystem_sandbox.dylib', 'libsystem_sanitizers.dylib', 'libsystem_secinit.dylib', 'libsystem_kernel.dylib', 'libsystem_platform.dylib', 'libsystem_pthread.dylib', 'libsystem_symptoms.dylib', 'libsystem_trace.dylib', 'libunwind.dylib', 'libxpc.dylib', 'libobjc.A.dylib', 'libc++abi.dylib', 'liboah.dylib', 'libc++.1.dylib', 'dyld']
me-mbp ~/w/frida$
```