### PR TITLE
installation.md: Switch to non-deprecated method

### DIFF
--- a/_i18n/en/_docs/installation.md
+++ b/_i18n/en/_docs/installation.md
@@ -48,7 +48,7 @@ $ cp /bin/cat /tmp/cat
 $ /tmp/cat
 {% endhighlight %}
 
-In another terminal, make a file example.py with the following contents:
+In another terminal, make a file `example.py` with the following contents:
 
 {% highlight py %}
 import frida
@@ -66,7 +66,7 @@ rpc.exports.enumerateModules = () => {
 script.on("message", on_message)
 script.load()
 
-print([m["name"] for m in script.exports.enumerate_modules()])
+print([m["name"] for m in script.exports_sync.enumerate_modules()])
 {% endhighlight %}
 
 If you are on GNU/Linux, issue:


### PR DESCRIPTION
When I ran this, I received a warning:
> DeprecationWarning: Script.exports will become asynchronous in the future, use the explicit Script.exports_sync instead

This fixes the issue