### PR TITLE
Mention JS exception thrown if an access error happened in Memory.scanSync

### DIFF
--- a/_i18n/en/_docs/javascript-api.md
+++ b/_i18n/en/_docs/javascript-api.md
@@ -667,6 +667,8 @@ Objects returned by e.g. [`Module.load()`](#module-load) and [`Process.enumerate
 
     -   `address`: absolute address as a [`NativePointer`](#nativepointer).
     -   `size`: size in bytes
+    -   
+    A JavaScript exception will be thrown if a memory access error occurred while scanning.
 
     For example:
 


### PR DESCRIPTION
Memory.scanSync throws JS exception if an access error happened while scanning the range, so I think it will be a good idea to mention that in the docs?